### PR TITLE
add failing test

### DIFF
--- a/test.js
+++ b/test.js
@@ -14,3 +14,7 @@ test('2 === 2', async t => {
 test('3 === 3', async t => {
   assert.equal(3, 3)
 })
+
+test('4 === 5', async t => {
+  assert.equal(4, 5)
+})


### PR DESCRIPTION
This PR shows that the expensive JavaScript linting and test steps will cause the `all-clear` branch rule to not pass.